### PR TITLE
Correction to volume test

### DIFF
--- a/volume_calc.py
+++ b/volume_calc.py
@@ -79,7 +79,12 @@ class Circ_parsor():
         for instruction in self.circ:
             if instruction.name not in RM_ops:
                 continue
-            current_stage_bd.remove(instruction.name)
+            try:
+                current_stage_bd.remove(instruction.name)
+                print(f"stage {current_stage.stage_name} removed {instruction.name}")
+            except ValueError:
+                print(f"stage {current_stage.stage_name} did not expect {instruction.name}")
+                raise
             gate_targets = instruction.targets_copy()
             if instruction.name in ['R','RX']:
                 for gate_target in gate_targets:

--- a/volume_calc_test.py
+++ b/volume_calc_test.py
@@ -1,0 +1,76 @@
+import stim
+from volume_calc import *
+
+filename = 'rp_3_T_cult'
+
+circ_path = './circuit_garage/' + filename + '.stim'
+res_path = './sample_results/' + filename + '_combined.csv'
+discard_res_path = './sample_results/' + filename + '_combined.csv'
+
+
+vol_helper = Circ_rp3_T_ungrown(circ_path)
+vol_helper.config_stages()
+vol_helper.active_qubits_calc()
+vol_helper.load_from_discard_tests(res_path)
+
+for stage in vol_helper.stages:
+    print(stage.stage_name,stage.active_qubits,stage.survival_rate,stage.det_stage)
+
+print("Volume for T-cult:", vol_helper.volume_calc(1/10))
+
+filename = 'rp_3_sc_7_end2end_4_full_rds'
+circ_path = './circuit_garage/' + filename + '.stim'
+res_path = './sample_results/' + filename + '_so2d_combined.csv'
+sc_d = 7
+n_rounds = 3
+
+vol_helper = Circ_rp3_T_end2end(circ_path,sc_d,n_rounds)
+vol_helper.config_stages()
+vol_helper.active_qubits_calc()
+vol_helper.load_from_discard_tests(discard_res_path)
+
+for stage in vol_helper.stages:
+    print(stage.stage_name, stage.active_qubits, stage.survival_rate, stage.det_stage)
+
+print(vol_helper.volume_calc(1/2.3),vol_helper.volume_calc(1/2.5))
+
+print("Volume for T-cult end2end:", vol_helper.volume_calc(1/10))
+
+
+
+filename = 'rp_3_rp_5_T_cult'
+circ_path = './circuit_garage/' + filename + '.stim'
+# res_path = './sample_results/' + filename + '_so2d_combined.csv'
+discard_res_path = './sample_results/' + filename + '_combined.csv'
+sc_d = 7
+n_rounds = 2
+
+vol_helper = Circ_rp5_T_ungrown(circ_path)
+vol_helper.config_stages()
+vol_helper.active_qubits_calc()
+vol_helper.load_from_discard_tests(discard_res_path)
+
+for stage in vol_helper.stages:
+    print(stage.stage_name, stage.active_qubits, stage.survival_rate, stage.det_stage)
+
+print(vol_helper.volume_calc(1/10))
+
+print("Volume for T-cult ungrown:", vol_helper.volume_calc(1/10))
+
+filename = 'rp_3_rp_5_sc_11_end2end_6_full_rds'
+circ_path = './circuit_garage/' + filename + '.stim'
+res_path = './sample_results/' + filename + '_so2d_combined.csv'
+sc_d = 11
+n_rounds = 5
+
+vol_helper = Circ_rp5_T_end2end(circ_path,sc_d,n_rounds)
+vol_helper.config_stages()
+vol_helper.active_qubits_calc()
+vol_helper.load_from_discard_tests(discard_res_path)
+
+for stage in vol_helper.stages:
+    print(stage.stage_name, stage.active_qubits, stage.survival_rate, stage.det_stage)
+
+print(vol_helper.volume_calc(1/15))
+
+print("Volume for T-cult end2end:", vol_helper.volume_calc(1/10))


### PR DESCRIPTION
Updated `n_rounds` in the rp-3 end-to-end test case so the parser builds the correct number of SE_SC-k stages.

rp_3_sc_7_end2end_4_full_rds.stim contains 4 surface-code rounds. The previous setting `n_rounds = 2` left the last two rounds un-staged, causing their `R RX M MX `tokens to spill into `PerfMeas` and trigger boundary errors. Aligning `n_rounds` with the file (now 3) keeps every round in its own SE_SC-k stage, lets a`ctive_qubits_calc()` run without extra `PerfMeas `tokens, and makes the volume test deterministic.